### PR TITLE
Update github-pages-deploy-action

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload documentation to gh-pages
         if: ${{ success() }}
-        uses: JamesIves/github-pages-deploy-action@3.6.1
+        uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages


### PR DESCRIPTION
Avoids the set-env problem, which is used in `3.6.1` and will cause a crash now that Github made the changes.