### PR TITLE
Unique indices Check Option

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,6 @@ jobs:
     name: ${{ matrix.os }} / ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
     name: ${{ matrix.os }} / ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
     - Took care of a numpy deprecation warning when using `np.str`, which should not appear anymore for users.
 
 - Changes:
-    - Prior to version `2.0.3`, reading and writing would raise `TfsFormatError` for `TfsDataFrames` with non-unique indices. This check is now disabled by default and left as an option to the user in said functions. Activating the check is as simple as setting the parameter `check_unique_indices` to `True`.
+    - Prior to version `2.0.3`, reading and writing would raise a `TfsFormatError` in case of non-unique indices or columns. These checks have been removed and are left to the user through new `TfsDataFrame` methods: `check_unique_indices` and `check_unique_columns`.
 
 ## Version 2.0.2
 - Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # TFS-Pandas Changelog
+
+## Version 2.0.3
+
+- Fixed:
+    - Took care of a numpy deprecation warning when using `np.str`, which should not appear anymore for users.
+
+- Changes:
+    - Prior to version `2.0.3`, reading and writing would raise `TfsFormatError` for `TfsDataFrames` with non-unique indices. This check is now disabled by default and left as an option to the user in said functions. Activating the check is as simple as setting the parameter `check_unique_indices` to `True`.
+
 ## Version 2.0.2
 - Fixed:
     - Proper error on non-string columns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@
     - Took care of a numpy deprecation warning when using `np.str`, which should not appear anymore for users.
 
 - Changes:
-    - Prior to version `2.0.3`, reading and writing would raise a `TfsFormatError` in case of non-unique indices or columns. These checks have been removed and are left to the user through a new `TfsDataFrame` method, `check_unique`.
+    - Prior to version `2.0.3`, reading and writing would raise a `TfsFormatError` in case of non-unique indices or columns. From now on, this behavior is an option in `read_tfs` and `write_tfs`called `non_unique_bahvior` which by default is set to log a warning. If explicitely asked by the user, the failed check will raise a `TfsFormatError`.
 
 ## Version 2.0.2
 - Fixed:
     - Proper error on non-string columns
     - Writing numeric-only mixed type dataframes bug
-    
+
 ## Version 2.0.1
 - Fixed:
     - No longer warns on MAD-X styled string column types (`%[num]s`).
@@ -40,7 +40,7 @@
     - Bug with testing for headers, also in pandas DataFrames
     - Same testing method for all data-frame comparisons
     - Some minor fixes
-    
+
 - Added:
     - Testing of writing of pandas DataFrames
 
@@ -55,7 +55,7 @@
 
  - Removed:
    - `.indx` from class (use `index="NAME"` instead)
-   
+
  - Fixed:
    - Writing of empty dataframes
    - Doc imports
@@ -78,7 +78,7 @@
 ## Version 1.0.1
  - Fixed: 
     - Metaclass-Bug in Collections
-    
+
  - Added: 
     - Additional Unit Tests
     - Versioning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
     - Took care of a numpy deprecation warning when using `np.str`, which should not appear anymore for users.
 
 - Changes:
-    - Prior to version `2.0.3`, reading and writing would raise a `TfsFormatError` in case of non-unique indices or columns. These checks have been removed and are left to the user through new `TfsDataFrame` methods: `check_unique_indices` and `check_unique_columns`.
+    - Prior to version `2.0.3`, reading and writing would raise a `TfsFormatError` in case of non-unique indices or columns. These checks have been removed and are left to the user through a new `TfsDataFrame` method, `check_unique`.
 
 ## Version 2.0.2
 - Fixed:

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -190,7 +190,7 @@ class TestFailures:
     def test_fail_on_non_unique_index(self, caplog):
         df = TfsDataFrame(index=["A", "B", "A"])
         with pytest.raises(TfsFormatError):
-            write_tfs("", df)
+            write_tfs("", df, check_unique_indices=True)
 
         for record in caplog.records:
             assert record.levelname == "ERROR"

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -178,19 +178,19 @@ class TestFailures:
         with pytest.raises(KeyError):
             _ = test_file["Not_HERE"]
 
-    def test_fail_on_non_unique_columns(self, caplog):
+    def test_raising_on_non_unique_columns(self, caplog):
         df = TfsDataFrame(columns=["A", "B", "A"])
         with pytest.raises(TfsFormatError):
-            write_tfs("", df)
+            df.check_unique_columns()
 
         for record in caplog.records:
             assert record.levelname == "ERROR"
-        assert "Non-unique column names found" in caplog.text
+        assert "Non-unique columns found" in caplog.text
 
-    def test_fail_on_non_unique_index(self, caplog):
+    def test_raising_on_non_unique_index(self, caplog):
         df = TfsDataFrame(index=["A", "B", "A"])
         with pytest.raises(TfsFormatError):
-            write_tfs("", df, check_unique_indices=True)
+            df.check_unique_indices()
 
         for record in caplog.records:
             assert record.levelname == "ERROR"

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -325,7 +325,7 @@ class TestWarnings:
 
         for record in caplog.records:
             assert record.levelname == "WARNING"
-        assert "An empty dataframe was provided, no types were infered" in caplog.text
+        assert "An empty dataframe was provided, no types were inferred" in caplog.text
 
     def test_warning_on_non_unique_columns(self, tmp_path, caplog):
         df = TfsDataFrame(columns=["A", "B", "A"])

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -181,7 +181,7 @@ class TestFailures:
     def test_raising_on_non_unique_columns(self, caplog):
         df = TfsDataFrame(columns=["A", "B", "A"])
         with pytest.raises(TfsFormatError):
-            df.check_unique_columns()
+            df.check_unique(check="columns")
 
         for record in caplog.records:
             assert record.levelname == "ERROR"
@@ -190,11 +190,20 @@ class TestFailures:
     def test_raising_on_non_unique_index(self, caplog):
         df = TfsDataFrame(index=["A", "B", "A"])
         with pytest.raises(TfsFormatError):
-            df.check_unique_indices()
+            df.check_unique(check="indices")
 
         for record in caplog.records:
             assert record.levelname == "ERROR"
         assert "Non-unique indices found" in caplog.text
+
+    def test_raising_on_non_unique_both(self, caplog):
+        df = TfsDataFrame(index=["A", "B", "A"], columns=["A", "B", "A"])
+        with pytest.raises(TfsFormatError):
+            df.check_unique()  # defaults to both
+
+        for record in caplog.records:
+            assert record.levelname == "ERROR"
+        assert "Non-unique indices or columns found" in caplog.text
 
     def test_fail_on_wrong_column_type(self, caplog):
         df = TfsDataFrame(columns=range(5))

--- a/tfs/__init__.py
+++ b/tfs/__init__.py
@@ -6,7 +6,7 @@ from tfs.handler import TfsDataFrame, read_tfs, write_tfs
 __title__ = "tfs-pandas"
 __description__ = "Read and write tfs files."
 __url__ = "https://github.com/pylhc/tfs"
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/tfs/handler.py
+++ b/tfs/handler.py
@@ -229,6 +229,12 @@ def _autoset_pandas_types(
     convert_dtypes() to internally use concat) and then return only a copy of the original
     dataframe. Otherwise, raise the exception given by pandas.
 
+    NOTE: Starting with pandas 1.3.0, this behavior which was a bug has been fixed. This means no
+    ValueError is raised by calling .convert_dtypes() on an empty DataFrame, and from this function
+    no warning is logged. Testing of this behavior is disabled for Python 3.7+ workers, but the
+    function is kept as to not force a new min version requirement on pandas or Python for users.
+    See my comment at https://github.com/pylhc/tfs/pull/83#issuecomment-874208869
+
     Args:
         data_frame (Union[TfsDataFrame, pd.DataFrame]): TfsDataFrame or pandas.DataFrame to
             determine the types of.

--- a/tfs/handler.py
+++ b/tfs/handler.py
@@ -240,14 +240,14 @@ def _autoset_pandas_types(
             determine the types of.
 
     Returns:
-        The dataframe with dtypes infered as much as possible to the pandas dtypes.
+        The dataframe with dtypes inferred as much as possible to the pandas dtypes.
     """
     LOGGER.debug("Attempting conversion of dataframe to pandas dtypes")
     try:
         return data_frame.copy().convert_dtypes(convert_integer=False)  # do not force floats to int
     except ValueError as pd_convert_error:  # If used on empty dataframes (uses concat internally)
         if not data_frame.size and "No objects to concatenate" in pd_convert_error.args[0]:
-            LOGGER.warning("An empty dataframe was provided, no types were infered")
+            LOGGER.warning("An empty dataframe was provided, no types were inferred")
             return data_frame.copy()  # since it's empty anyway, nothing to convert
         else:
             raise pd_convert_error

--- a/tfs/handler.py
+++ b/tfs/handler.py
@@ -91,17 +91,29 @@ class TfsDataFrame(pd.DataFrame):
             s += "\n"
         return f"{s}{super().__repr__()}"
 
-    def check_unique_indices(self):
-        """Checks that the object has unique indices, raises a ``TfsFormatError`` if it does not."""
-        if self.index.has_duplicates:
+    def check_unique(self, check: str = "both") -> None:
+        """
+        Checks that indices, columns or both contain unique values, raises TfsFormatError if not.
+        By default, checks both.
+
+        Args:
+            check (str): which elements to check, either 'columns', 'indices' or 'both'. The parameter
+                is not case sensitive, and defauts to 'both'.
+
+        Raises:
+            Raises a ``TfsFormatError`` if the check find non-unique elements.
+        """
+        if check.lower() not in ("indices", "columns", "both"):
+            raise KeyError("The 'check' parameter should be one of 'indices', 'columns' or 'both'")
+        if check.lower() == "indices" and self.index.has_duplicates:
             LOGGER.error("Non-unique indices found")
             raise TfsFormatError("Indices are not unique.")
-
-    def check_unique_columns(self):
-        """Checks that the object has unique columns, raises a ``TfsFormatError`` if it does not."""
-        if self.columns.has_duplicates:
+        if check.lower() == "columns" and self.columns.has_duplicates:
             LOGGER.error("Non-unique columns found")
-            raise TfsFormatError("Columns are not unique")
+            raise TfsFormatError("Columns are not unique.")
+        if check.lower() == "both" and (self.index.has_duplicates or self.columns.has_duplicates):
+            LOGGER.error("Non-unique indices or columns found")
+            raise TfsFormatError("Indices or columns are not unique.")
 
 
 def read_tfs(tfs_file_path: Union[pathlib.Path, str], index: str = None) -> TfsDataFrame:

--- a/tfs/handler.py
+++ b/tfs/handler.py
@@ -93,9 +93,7 @@ class TfsDataFrame(pd.DataFrame):
 
 
 def read_tfs(
-    tfs_file_path: Union[pathlib.Path, str],
-    index: str = None,
-    check_unique_indices: bool = False
+    tfs_file_path: Union[pathlib.Path, str], index: str = None, check_unique_indices: bool = False
 ) -> TfsDataFrame:
     """
     Parses the TFS table present in **tfs_file_path** and returns a customized version of a Pandas
@@ -446,7 +444,9 @@ class TfsFormatError(Exception):
 
 
 def _validate(
-    data_frame: Union[TfsDataFrame, pd.DataFrame], info_str: str = "", check_unique_indices: bool = False
+    data_frame: Union[TfsDataFrame, pd.DataFrame],
+    info_str: str = "",
+    check_unique_indices: bool = False,
 ) -> None:
     """
     Check if Dataframe contains finite values only and both indices and columns are unique.

--- a/tfs/handler.py
+++ b/tfs/handler.py
@@ -447,10 +447,7 @@ class TfsFormatError(Exception):
     pass
 
 
-def _validate(
-    data_frame: Union[TfsDataFrame, pd.DataFrame],
-    info_str: str = "",
-) -> None:
+def _validate(data_frame: Union[TfsDataFrame, pd.DataFrame], info_str: str = "") -> None:
     """
     Check if Dataframe contains finite values only, strings as column names and no empty headers
     or column names.

--- a/tfs/handler.py
+++ b/tfs/handler.py
@@ -91,10 +91,20 @@ class TfsDataFrame(pd.DataFrame):
             s += "\n"
         return f"{s}{super().__repr__()}"
 
+    def check_unique_indices(self):
+        """Checks that the object has unique indices, raises a ``TfsFormatError`` if it does not."""
+        if self.index.has_duplicates:
+            LOGGER.error("Non-unique indices found")
+            raise TfsFormatError("Indices are not unique.")
 
-def read_tfs(
-    tfs_file_path: Union[pathlib.Path, str], index: str = None, check_unique_indices: bool = False
-) -> TfsDataFrame:
+    def check_unique_columns(self):
+        """Checks that the object has unique columns, raises a ``TfsFormatError`` if it does not."""
+        if self.columns.has_duplicates:
+            LOGGER.error("Non-unique columns found")
+            raise TfsFormatError("Columns are not unique")
+
+
+def read_tfs(tfs_file_path: Union[pathlib.Path, str], index: str = None) -> TfsDataFrame:
     """
     Parses the TFS table present in **tfs_file_path** and returns a customized version of a Pandas
     DataFrame (a TfsDataFrame).
@@ -104,8 +114,6 @@ def read_tfs(
             a string, in which case it will be cast to a PosixPath object.
         index (str): Name of the column to set as index. If not given, looks in **tfs_file_path**
             for a column starting with `INDEX&&&`.
-        check_unique_indices (bool): Flag to check that the read file has unique indices. If set to ``True``
-            and indices are not unique, a ``TfsFormatError`` will be raised. Defaults to False.
 
     Returns:
         A TfsDataFrame object.
@@ -154,7 +162,7 @@ def read_tfs(
                 index_name = None  # to remove it completely (Pandas makes a difference)
             data_frame = data_frame.rename_axis(index_name)
 
-    _validate(data_frame, f"from file {tfs_file_path.absolute()}", check_unique_indices)
+    _validate(data_frame, f"from file {tfs_file_path.absolute()}")
     return data_frame
 
 
@@ -165,7 +173,6 @@ def write_tfs(
     save_index: Union[str, bool] = False,
     colwidth: int = DEFAULT_COLUMN_WIDTH,
     headerswidth: int = DEFAULT_COLUMN_WIDTH,
-    check_unique_indices: bool = False,
 ) -> None:
     """
     Writes the DataFrame into **tfs_file_path** with the `headers_dict` as headers dictionary. If
@@ -183,13 +190,10 @@ def write_tfs(
             saves the index of the data_frame to a column named by the provided value.
         colwidth (int): Column width, can not be smaller than `MIN_COLUMN_WIDTH`.
         headerswidth (int): Used to format the header width for both keys and values.
-        check_unique_indices (bool): Flag to check that the dataframe to be written has unique indices. If
-            set to ``True`` and indices are not unique, a ``TfsFormatError`` will be raised. Defaults to
-            ``False``.
     """
     left_align_first_column = False
     tfs_file_path = pathlib.Path(tfs_file_path)
-    _validate(data_frame, f"to be written in {tfs_file_path.absolute()}", check_unique_indices)
+    _validate(data_frame, f"to be written in {tfs_file_path.absolute()}")
 
     if headers_dict is None:  # tries to get headers from TfsDataFrame
         try:
@@ -446,16 +450,14 @@ class TfsFormatError(Exception):
 def _validate(
     data_frame: Union[TfsDataFrame, pd.DataFrame],
     info_str: str = "",
-    check_unique_indices: bool = False,
 ) -> None:
     """
-    Check if Dataframe contains finite values only and both indices and columns are unique.
+    Check if Dataframe contains finite values only, strings as column names and no empty headers
+    or column names.
 
     Args:
         data_frame (Union[TfsDataFrame, pd.DataFrame]): the dataframe to check on.
         info_str (str): additional information to includ in logging statements.
-        check_unique_indices (bool): Flag to check that the dataframe has unique indices. If set to
-            ``True`` and indices are not unique, a ``TfsFormatError`` will be raised. Defaults to ``False``.
     """
 
     def is_not_finite(x):
@@ -474,14 +476,6 @@ def _validate(
             f"DataFrame {info_str} contains non-physical values at Index: "
             f"{boolean_df.index[boolean_df.any(axis='columns')].tolist()}"
         )
-
-    if check_unique_indices and len(set(data_frame.index)) != len(data_frame.index):
-        LOGGER.error(f"Non-unique indices found, dataframe {info_str} is invalid")
-        raise TfsFormatError("Indices are not Unique.")
-
-    if len(set(data_frame.columns)) != len(data_frame.columns):
-        LOGGER.error(f"Non-unique column names found, dataframe {info_str} is invalid")
-        raise TfsFormatError("Column names not Unique.")
 
     if any(not isinstance(c, str) for c in data_frame.columns):
         LOGGER.error(f"Some column-names are not of string-type, dataframe {info_str} is invalid.")


### PR DESCRIPTION
This is a proposal for an implementation that closes #82 

The check is removed from `_validate`, and won't be performed when reading or writing.
A method for `TfsDataFrame` has been created which performs the check.
If the check is needed, the user can explicitely call the method.

Also updates the changelog and ups version to `2.0.3`. This is a good opportunity for a patch that would also include our fix of a deprecation warning from `numpy` (see: 0c71f6691d51667a389b3270794a212584f862df).

Feedback and discussion welcome