### PR TITLE
Add .zenodo_json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,38 @@
+{
+    "creators": [
+        {
+            "name": "OMC-Team",
+            "affiliation": "CERN"
+        },
+        {
+            "name": "Michael Hofer",
+            "affiliation": "CERN",
+            "orcid": "0000-0001-6173-0232"
+        },
+        {
+            "name": "Joschua Dilly",
+            "affiliation": "CERN",
+            "orcid": "0000-0001-7864-5448"
+        },
+        {
+            "name": "Felix Soubelet",
+            "affiliation": "University of Liverpool & CERN",
+            "orcid": "0000-0001-8012-1440"
+        },
+        {
+            "name": "Lukáš Malina",
+            "affiliation": "CERN"
+        },
+        {
+            "name": "Rogelio Tomas Garcia",
+            "affiliation": "CERN",
+            "orcid": "0000-0002-9857-1703"
+        },
+        {
+            "name": "Tobias Persson",
+            "affiliation": "CERN"
+        }
+    ],
+    "title": "TFS-Pandas",
+    "description": "Python 3 package to handle TFS files."
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -24,6 +24,10 @@
             "affiliation": "CERN"
         },
         {
+            "name": "Maël Le Garrec",
+            "affiliation": "CERN"
+        },
+        {
             "name": "Rogelio Tomas Garcia",
             "affiliation": "CERN",
             "orcid": "0000-0002-9857-1703"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -21,11 +21,13 @@
         },
         {
             "name": "Lukáš Malina",
-            "affiliation": "CERN"
+            "affiliation": "CERN",
+            "orcid": "0000-0002-4673-6035"
         },
         {
             "name": "Maël Le Garrec",
-            "affiliation": "CERN"
+            "affiliation": "CERN",
+            "orcid": "0000-0002-8146-2340"
         },
         {
             "name": "Rogelio Tomas Garcia",

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Code Climate maintainability (percentage)](https://img.shields.io/codeclimate/maintainability-percentage/pylhc/tfs.svg?style=popout)](https://codeclimate.com/github/pylhc/tfs)
 [![GitHub last commit](https://img.shields.io/github/last-commit/pylhc/tfs.svg?style=popout)](https://github.com/pylhc/tfs/)
 [![GitHub release](https://img.shields.io/github/release/pylhc/tfs.svg?style=popout)](https://github.com/pylhc/tfs/)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5070986.svg)](https://doi.org/10.5281/zenodo.5070986)
 
 This package provides reading and writing functionality for **table format system (tfs)** files. 
 


### PR DESCRIPTION
Adding a  `.zenodo.json` file, taken from the `PyLHC` one.
Also adds a DOI badge to the README, pointing to the "all releases" DOI from Zenodo.

Not fully sure who else should be added, suggestions welcome.