### PR TITLE
Documentation build fix

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -79,7 +79,7 @@ master_doc = "index"
 
 # General information about the project.
 project = ABOUT_TFS["__title__"]
-copyright_ = "2018-2021, pyLHC/OMC-TEAM"
+copyright_ = "2018, pyLHC/OMC-TEAM"
 author = ABOUT_TFS["__author__"]
 
 # Override link in 'Edit on Github'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -131,13 +131,13 @@ html_theme_options = {
 html_logo = "_static/img/omc_logo.svg"
 html_static_path = ["_static"]
 html_context = {
-    "css_files": ["_static/css/custom.css"],
     "display_github": True,
     # the following are only needed if :github_url: is not set
     "github_user": author,
     "github_repo": project,
     "github_version": "master/doc/",
 }
+html_css_files = ["css/custom.css"]
 
 smartquotes_action = "qe"  # renders only quotes and ellipses (...) but not dashes (option: D)
 


### PR DESCRIPTION
Since `sphinx-rtd-theme` has released `1.0`, our documentation has built wrongly to say the least.

This is the fix making things compatible with `>=1.0`, and restoring the doc pages to their normal state.
Thanks to @JoschD for quickly finding the fix.