### PR TITLE
Change logger level to debug when raising an exception in read_tfs

### DIFF
--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -70,20 +70,14 @@ class TestFailures:
             _ = tfs.reader._id_to_type(unexpected_id)
 
     def test_fail_read_no_coltypes(self, _no_coltypes_tfs_path, caplog):
-        with pytest.raises(TfsFormatError):
+        with pytest.raises(TfsFormatError) as e:
             _ = read_tfs(_no_coltypes_tfs_path)
-
-        for record in caplog.records:
-            assert record.levelname == "ERROR"
-        assert "No column types in file" in caplog.text
+        assert "column types" in str(e)
 
     def test_fail_read_no_colnames(self, _no_colnames_tfs_path, caplog):
-        with pytest.raises(TfsFormatError):
+        with pytest.raises(TfsFormatError) as e:
             _ = read_tfs(_no_colnames_tfs_path)
-
-        for record in caplog.records:
-            assert record.levelname == "ERROR"
-        assert "No column names in file" in caplog.text
+        assert "column names" in str(e)
 
     def test_id_to_type_handles_typo_str_id(self):
         typoed_str_id = "%%s"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -319,7 +319,7 @@ def _messed_up_dataframe() -> TfsDataFrame:
     """Returns a TfsDataFrame with mixed types in each column, some elements being lists."""
     int_row = numpy.array([random.randint(-1e5, 1e5) for _ in range(4)], dtype=numpy.float64)
     float_row = numpy.array([round(random.uniform(-1e5, 1e5), 7) for _ in range(4)], dtype=numpy.float64)
-    string_row = numpy.array([_rand_string() for _ in range(4)], dtype=numpy.str)
+    string_row = numpy.array([_rand_string() for _ in range(4)], dtype=str)
     list_floats_row = [[1.0, 14.777], [2.0, 1243.9], [3.0], [123414.0, 9909.12795]]
     return TfsDataFrame(
         index=range(4),

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -174,7 +174,7 @@ class TestFailures:
             write_tfs("", df)
 
         for record in caplog.records:
-            assert record.levelname == "ERROR"
+            assert record.levelname == "DEBUG"
         assert "not of string-type" in caplog.text
 
     def test_fail_on_spaces_columns(self, caplog):
@@ -183,7 +183,7 @@ class TestFailures:
             write_tfs("", df)
 
         for record in caplog.records:
-            assert record.levelname == "ERROR"
+            assert record.levelname == "DEBUG"
         assert "Space(s) found in TFS columns" in caplog.text
 
     def test_fail_on_spaces_headers(self, caplog):
@@ -192,7 +192,7 @@ class TestFailures:
             write_tfs("", df)
 
         for record in caplog.records:
-            assert record.levelname == "ERROR"
+            assert record.levelname == "DEBUG"
         assert "Space(s) found in TFS header names" in caplog.text
 
     def test_messed_up_dataframe_fails_writes(self, _messed_up_dataframe: TfsDataFrame):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -169,6 +169,7 @@ class TestFailures:
         assert "Non-unique indices found" in caplog.text  # first checked and raised
 
     def test_fail_on_wrong_column_type(self, caplog):
+        caplog.set_level(logging.DEBUG)
         df = TfsDataFrame(columns=range(5))
         with pytest.raises(TfsFormatError):
             write_tfs("", df)
@@ -178,6 +179,7 @@ class TestFailures:
         assert "not of string-type" in caplog.text
 
     def test_fail_on_spaces_columns(self, caplog):
+        caplog.set_level(logging.DEBUG)
         df = TfsDataFrame(columns=["allowed", "not allowed"])
         with pytest.raises(TfsFormatError):
             write_tfs("", df)
@@ -187,6 +189,7 @@ class TestFailures:
         assert "Space(s) found in TFS columns" in caplog.text
 
     def test_fail_on_spaces_headers(self, caplog):
+        caplog.set_level(logging.DEBUG)
         df = TfsDataFrame(headers={"allowed": 1, "not allowed": 2})
         with pytest.raises(TfsFormatError):
             write_tfs("", df)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 import random
 import string

--- a/tfs/__init__.py
+++ b/tfs/__init__.py
@@ -9,7 +9,7 @@ from tfs.writer import write_tfs
 __title__ = "tfs-pandas"
 __description__ = "Read and write tfs files."
 __url__ = "https://github.com/pylhc/tfs"
-__version__ = "3.0.2"
+__version__ = "3.1.0"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/tfs/frame.py
+++ b/tfs/frame.py
@@ -343,15 +343,15 @@ def validate(
 
     # The following are deal-breakers for the TFS format and would not, for instance, be accepted by MAD-X
     if any(not isinstance(c, str) for c in data_frame.columns):
-        LOGGER.error(f"Some column-names are not of string-type, dataframe {info_str} is invalid.")
+        LOGGER.debug(f"Some column-names are not of string-type, dataframe {info_str} is invalid.")
         raise TfsFormatError("TFS-Columns need to be strings.")
 
     if any(" " in c for c in data_frame.columns):
-        LOGGER.error(f"Space(s) found in TFS columns, dataframe {info_str} is invalid")
+        LOGGER.debug(f"Space(s) found in TFS columns, dataframe {info_str} is invalid")
         raise TfsFormatError("TFS-Columns can not contain spaces.")
 
     if hasattr(data_frame, "headers") and any(" " in h for h in data_frame.headers.keys()):
-        LOGGER.error(f"Space(s) found in TFS header names, dataframe {info_str} is invalid")
+        LOGGER.debug(f"Space(s) found in TFS header names, dataframe {info_str} is invalid")
         raise TfsFormatError("TFS-Header names can not contain spaces.")
 
     LOGGER.debug(f"DataFrame {info_str} validated")

--- a/tfs/reader.py
+++ b/tfs/reader.py
@@ -72,10 +72,10 @@ def read_tfs(
                 break  # Break to not go over all lines, saves a lot of time on big files
 
     if column_names is None:
-        LOGGER.error(f"No column names in file {tfs_file_path.absolute()}, aborting")
+        LOGGER.debug(f"No column names in file {tfs_file_path.absolute()}, aborting")
         raise TfsFormatError("Column names have not been set.")
     if column_types is None:
-        LOGGER.error(f"No column types in file {tfs_file_path.absolute()}, aborting")
+        LOGGER.debug(f"No column types in file {tfs_file_path.absolute()}, aborting")
         raise TfsFormatError("Column types have not been set.")
 
     LOGGER.debug("Parsing data part of the file")

--- a/tfs/reader.py
+++ b/tfs/reader.py
@@ -72,11 +72,9 @@ def read_tfs(
                 break  # Break to not go over all lines, saves a lot of time on big files
 
     if column_names is None:
-        LOGGER.debug(f"No column names in file {tfs_file_path.absolute()}, aborting")
-        raise TfsFormatError("Column names have not been set.")
+        raise TfsFormatError(f"No column names in file {tfs_file_path.absolute()}. File not read.")
     if column_types is None:
-        LOGGER.debug(f"No column types in file {tfs_file_path.absolute()}, aborting")
-        raise TfsFormatError("Column types have not been set.")
+        raise TfsFormatError(f"No column types in file {tfs_file_path.absolute()}. File not read.")
 
     LOGGER.debug("Parsing data part of the file")
     # DO NOT use comment=COMMENTS in here, if you do and the symbol is in an element for some


### PR DESCRIPTION
An exception is not really an error, at least not in Python, so when I am
explicitly relying on for example the raising of a `TfsFormatError` in
`read_tfs` (before trying a different loader for what is presumably a different
file type), seeing:

        LOGGER.error(f"No column names in file {tfs_file_path.absolute()}, aborting")

is not really welcome or appropriate...  it's not even immediately clear to the
user where this talk of "aborting" is coming from due to the way the logger
formatter is configured, so it is quite alarming and annoying to be doing very
normal code and seeing "aborting"...  This should at most be `LOGGER.debug`, not
`LOGGER.error`, I would suggest.