### PR TITLE
Python 3.11 in Github Workflows and Readme additions

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
         # Make sure to escape 3.10 with quotes so it doesn't get interpreted as float 3.1 by GA's parser
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.x]  # crons should always run latest python hence 3.x
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", 3.x]  # crons should always run latest python hence 3.x
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
         # Make sure to escape 3.10 with quotes so it doesn't get interpreted as float 3.1 by GA's parser
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -10,9 +10,15 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5070986.svg)](https://doi.org/10.5281/zenodo.5070986)
 
 This package provides reading and writing functionality for [**table format system (tfs)** files](http://mad.web.cern.ch/mad/madx.old/Introduction/tfs.html). 
-Files are read into a `TfsDataFrame`, a class built on top of the famous `pandas.DataFrame`, which in addition to the normal behaviour attaches an `OrderedDict` of headers to the `DataFrame`.
+Files are read into a `TfsDataFrame`, a class built on top of the famous `pandas.DataFrame`, which in addition to the normal behavior attaches an `OrderedDict` of headers to the `DataFrame`.
 
 See the [API documentation](https://pylhc.github.io/tfs/) for details.
+
+<details>
+  <summary>**Note:** Package Scope</summary>
+        The `tfs-pandas` package is made to handle IO of TFS files and some related utilities.
+        It is not meant to implement calculations on `TfsDataFrames`, which is functionality implemented in other packages of the `PyLHC` ecosystem.
+</details>
 
 ## Installing
 
@@ -21,7 +27,7 @@ Installation is easily done via `pip`:
 python -m pip install tfs-pandas
 ```
 
-One can also install in a `conda` environment via the `conda-forge` channel with:
+One can also install in a `conda`/`mamba` environment via the `conda-forge` channel with:
 ```bash
 conda install -c conda-forge tfs-pandas
 ```
@@ -50,7 +56,7 @@ tfs.write("path_to_output.tfs", data_frame, save_index="index_column")
 ```
 
 It also provides some tools to validate and manipulate `TfsDataFrames` and their headers; or lazily manage a collection of TFS files.
-With `tfs.read_hdf()` and `tfs.write_hdf()` the `TfsDataFames` can also be saved as `hdf5` files, if the `hdf5` extra-requirements are fullfilled.
+With `tfs.read_hdf()` and `tfs.write_hdf()` the `TfsDataFames` can also be saved as `hdf5` files, if the `hdf5` extra-requirements are fulfilled.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Conda-forge Version](https://img.shields.io/conda/vn/conda-forge/tfs-pandas?color=orange&logo=anaconda)](https://anaconda.org/conda-forge/tfs-pandas)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5070986.svg)](https://doi.org/10.5281/zenodo.5070986)
 
-This package provides reading and writing functionality for [**table format system (tfs)** files](http://mad.web.cern.ch/mad/madx.old/Introduction/tfs.html). 
+This package provides reading and writing functionality for [**Table Format System (TFS)** files](http://mad.web.cern.ch/mad/madx.old/Introduction/tfs.html). 
 Files are read into a `TfsDataFrame`, a class built on top of the famous `pandas.DataFrame`, which in addition to the normal behavior attaches an `OrderedDict` of headers to the `DataFrame`.
 
 See the [API documentation](https://pylhc.github.io/tfs/) for details.

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ Files are read into a `TfsDataFrame`, a class built on top of the famous `pandas
 See the [API documentation](https://pylhc.github.io/tfs/) for details.
 
 <details>
-  <summary>**Note:** Package Scope</summary>
-        The `tfs-pandas` package is made to handle IO of TFS files and some related utilities.
-        It is not meant to implement calculations on `TfsDataFrames`, which is functionality implemented in other packages of the `PyLHC` ecosystem.
+  <summary>Note: Package Scope</summary>
+
+This package is made to handle I/O of `TFS` files to `TfsDataFrames` only: it is not meant to implement calculations on `TfsDataFrames`. Various calculations are implemented in other packages of the ecosystem.
+
 </details>
 
 ## Installing

--- a/README.md
+++ b/README.md
@@ -14,13 +14,6 @@ Files are read into a `TfsDataFrame`, a class built on top of the famous `pandas
 
 See the [API documentation](https://pylhc.github.io/tfs/) for details.
 
-<details>
-  <summary>Note: Package Scope</summary>
-
-This package is made to handle I/O of `TFS` files to `TfsDataFrames` only: it is not meant to implement calculations on `TfsDataFrames`. Various calculations are implemented in other packages of the ecosystem.
-
-</details>
-
 ## Installing
 
 Installation is easily done via `pip`:
@@ -56,8 +49,13 @@ tfs.frame.validate(data_frame, non_unique_behavior="raise")  # or choose "warn"
 tfs.write("path_to_output.tfs", data_frame, save_index="index_column")
 ```
 
-It also provides some tools to validate and manipulate `TfsDataFrames` and their headers; or lazily manage a collection of TFS files.
-With `tfs.read_hdf()` and `tfs.write_hdf()` the `TfsDataFames` can also be saved as `hdf5` files, if the `hdf5` extra-requirements are fulfilled.
+### Package Scope
+
+The package also provides some tools to validate and manipulate `TfsDataFrames` and their headers; or lazily manage a collection of TFS files.
+For instance with `tfs.read_hdf()` and `tfs.write_hdf()` the `TfsDataFames` can also be saved as `hdf5` files, if the `hdf5` extra-requirements are fulfilled.
+
+The package, however, is made to handle I/O of `TFS` files to `TfsDataFrames` only: it is not meant to implement various calculations on `TfsDataFrames`.
+Some calculations are implemented in other packages of the ecosystem.
 
 ## License
 


### PR DESCRIPTION
Adding 3.11 in workflows now that `cpymad` has wheels for it for all platforms.
Adding a small section in the README about the scope limitation of the package.

Will get this through myself as no code change is involved.