### PR TITLE
Pandas 2.x restraint

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
         # Make sure to escape 3.10 with quotes so it doesn't get interpreted as float 3.1 by GA's parser
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11", 3.x]  # crons should always run latest python hence 3.x
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
         # Make sure to escape 3.10 with quotes so it doesn't get interpreted as float 3.1 by GA's parser
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # TFS-Pandas Changelog
 
+## Version 3.5.2
+
+- Changed:
+  - The dependency on `pandas` has been pinned to `<2.0` to guarantee the proper functionning of the compability `append`, `join` and `merge` methods in `TfsDataFrames`. These will be removed with the next release of `tfs-pandas` and users should use the `tfs.frame.concat` compatibility function instead.
+
 ## Version 3.5.1
 
 - Fixed:

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ with README.open("r") as docs:
 # Dependencies for the package itself
 DEPENDENCIES = [
     "numpy>=1.19.0",
-    "pandas>=1.0",
+    "pandas<2.0",
 ]
 
 # Extra dependencies

--- a/tfs/__init__.py
+++ b/tfs/__init__.py
@@ -10,7 +10,7 @@ from tfs.writer import write_tfs
 __title__ = "tfs-pandas"
 __description__ = "Read and write tfs files."
 __url__ = "https://github.com/pylhc/tfs"
-__version__ = "3.5.1"
+__version__ = "3.5.2"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/tfs/frame.py
+++ b/tfs/frame.py
@@ -93,6 +93,11 @@ class TfsDataFrame(pd.DataFrame):
         manipulation is done by the ``pandas.Dataframe`` method of the same name. Resulting headers are
         either merged according to the provided **how_headers** method or as given via **new_headers**.
 
+        ..warning::
+            This method uses ``pandas.DataFrame.append`` internally, which has been deprecated for a
+            while and removed with pandas 2.0. It will be removed from ``tfs-pandas`` as well in the
+            next release.
+
         Args:
             other (Union[TfsDataFrame, pd.DataFrame]): The ``TfsDataFrame`` to append to the caller.
             how_headers (str): Type of merge to be performed for the headers. Either **left** or **right**.
@@ -111,6 +116,7 @@ class TfsDataFrame(pd.DataFrame):
         Returns:
             A new ``TfsDataFrame`` with the appended data and merged headers.
         """
+        LOGGER.warn("This method has been removed in pandas 2.0 and will be removed from TfsDataFrames too. Please use 'tfs.frame.concat' instead.")
         LOGGER.debug("Appending data through 'pandas'")
         if not hasattr(other, "headers"):
             LOGGER.debug("Converting 'other' to TfsDataFrame for appending")
@@ -138,6 +144,11 @@ class TfsDataFrame(pd.DataFrame):
         method of the same name. Resulting headers are either merged according to the provided
         **how_headers** method or as given via **new_headers**.
 
+        ..warning::
+            This method uses ``pandas.DataFrame.join`` internally, which has been deprecated for a
+            while and removed with pandas 2.0. It will be removed from ``tfs-pandas`` as well in the
+            next release.
+
         Args:
             other (Union[TfsDataFrame, pd.DataFrame]): The ``TfsDataFrame`` to join into the caller.
             how_headers (str): Type of merge to be performed for the headers. Either **left** or **right**.
@@ -156,6 +167,7 @@ class TfsDataFrame(pd.DataFrame):
         Returns:
             A new ``TfsDataFrame`` with the joined columns and merged headers.
         """
+        LOGGER.warn("This method has been removed in pandas 2.0 and will be removed from TfsDataFrames too. Please use 'tfs.frame.concat' instead.")
         LOGGER.debug("Joining data through 'pandas'")
         if not hasattr(other, "headers"):
             LOGGER.debug("Converting 'other' to TfsDataFrame for joining")
@@ -182,6 +194,11 @@ class TfsDataFrame(pd.DataFrame):
         ``pandas.Dataframe`` method of the same name. Resulting headers are either merged according to the
         provided **how_headers** method or as given via **new_headers**.
 
+        ..warning::
+            This method uses ``pandas.DataFrame.merge`` internally, which has been deprecated for a
+            while and removed with pandas 2.0. It will be removed from ``tfs-pandas`` as well in the
+            next release.
+
         Args:
             right (Union[TfsDataFrame, pd.DataFrame]): The ``TfsDataFrame`` to merge with the caller.
             how_headers (str): Type of merge to be performed for the headers. Either **left** or **right**.
@@ -200,6 +217,7 @@ class TfsDataFrame(pd.DataFrame):
         Returns:
             A new ``TfsDataFrame`` with the merged data and merged headers.
         """
+        LOGGER.warn("This method has been removed in pandas 2.0 and will be removed from TfsDataFrames too. Please use 'tfs.frame.concat' instead.")
         LOGGER.debug("Merging data through 'pandas'")
         if not hasattr(right, "headers"):
             LOGGER.debug("Converting 'right' to TfsDataFrame for merging")


### PR DESCRIPTION
As of `pandas` `2.0` the `append`, `join` and `merge` methods have been removed from `pandas.DataFrame`. This has been failing our CIs.

This patch version forces `pandas<2.0` to guarantee the compatibility methods provided for `TfsDataFrames` work. They will be removed in a future version to enable compatibility with `pandas` `2.x`.

In this patch, a warning is added to the documentation of said methods and also logged when used, redirecting the users to `tfs.frame.concat`.