### PR TITLE
Migrate to common workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,28 +1,26 @@
-# Continuous Integration Workflows
+# Continous Integration Workflows
 
-This package implements different workflows for CI.
-They are organized as follows.
+This package implements different workflows for CI, based on our organisation's common workflows.
+They are organised as follows.
 
 ### Documentation
 
 The `documentation` workflow triggers on any push to master, builds the documentation and pushes it to the `gh-pages` branch (if the build is successful).
-It runs on `ubuntu-latest` and our lowest supported Python version, `Python 3.7`.
 
 ### Testing Suite
 
 Tests are ensured in the `tests` workflow, which triggers on all pushes.
-It runs on a matrix of all supported operating systems (ubuntu-18.04, ubuntu-20.04, windows-latest and macos-latest) for all supported Python versions (currently `3.7`, `3.8`, `3.9`, `3.10` and `3.11`).
+It runs on a matrix of all supported operating systems for all supported Python versions.
 
 ### Test Coverage
 
 Test coverage is calculated in the `coverage` wokflow, which triggers on pushes to `master` and any push to a `pull request`.
-It runs on `ubuntu-latest` & the lowest supported Python version (`Python 3.7`), and reports the coverage results of the test suite to `CodeClimate`,
-
+It reports the coverage results of the test suite to `CodeClimate`.
 
 ### Regular Testing
 
 A `cron` workflow triggers every Monday at 3am (UTC time) and runs the full testing suite, on all available operating systems and supported Python versions.
-It also runs on `Python 3.x` so that newly released Python versions that would break tests are automatically detected.
+It also runs on `Python 3.x` so that newly released Python versions that would break tests are automatically included.
 
 ### Publishing
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,10 +1,6 @@
 # Runs all tests and pushes coverage report to codeclimate
 name: Coverage
 
-defaults:
-  run:
-    shell: bash
-
 on:  # Runs on all push events to master branch and any push related to a pull request
   push:
     branches:
@@ -13,56 +9,7 @@ on:  # Runs on all push events to master branch and any push related to a pull r
 
 jobs:
   coverage:
-    name: ${{ matrix.os }} / ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:  # only lowest supported Python on latest ubuntu
-        os: [ubuntu-latest]
-        python-version: [3.7]
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/setup.py'
-
-      - name: Upgrade pip, setuptools and wheel
-        run: python -m pip install --upgrade pip setuptools wheel
-
-      - name: Install package
-        run: python -m pip install '.[test,hdf5]'
-
-      - name: Set up env for CodeClimate (push)
-        run: |
-          echo "GIT_BRANCH=${GITHUB_REF/refs\/heads\//}" >> $GITHUB_ENV
-          echo "GIT_COMMIT_SHA=$GITHUB_SHA" >> $GITHUB_ENV
-        if: github.event_name == 'push'
-
-      - name: Set up env for CodeClimate (pull_request)
-        env:
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          echo "GIT_BRANCH=$GITHUB_HEAD_REF" >> $GITHUB_ENV
-          echo "GIT_COMMIT_SHA=$PR_HEAD_SHA" >> $GITHUB_ENV
-        if: github.event_name == 'pull_request'
-
-      - name: Prepare CodeClimate binary
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        run: |
-          curl -LSs 'https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64' >./cc-test-reporter;
-          chmod +x ./cc-test-reporter
-          ./cc-test-reporter before-build
-
-      - name: Run tests
-        run: python -m pytest --cov-report xml --cov=tfs
-
-      - name: Push Coverage to CodeClimate
-        if: ${{ success() }}  # only if tests were successful
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        run: ./cc-test-reporter after-build
+      uses: pylhc/.github/.github/workflows/coverage.yml@master
+      with:
+        src-dir: tfs
+      secrets: inherit

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,39 +1,13 @@
-# Runs all tests on master everyday at 10 am (UTC time)
+# Runs all tests on master on Mondays at 3 am (UTC time)
 name: Cron Testing
 
-defaults:
-  run:
-    shell: bash
 
-on:  # Runs on master branch on Mondays at 3am UTC time
+on: 
   schedule:
     - cron:  '* 3 * * mon'
 
 jobs:
-  tests:
-    name: ${{ matrix.os }} / ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
-        # Make sure to escape 3.10 with quotes so it doesn't get interpreted as float 3.1 by GA's parser
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", 3.x]  # crons should always run latest python hence 3.x
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/setup.py'
-
-      - name: Upgrade pip, setuptools and wheel
-        run: python -m pip install --upgrade pip setuptools wheel
-
-      - name: Install package
-        run: python -m pip install '.[test,hdf5]'
-
-      - name: Run tests
-        run: python -m pytest
+    tests:
+      uses: pylhc/.github/.github/workflows/cron.yml@master
+      with:
+        extra-dependencies: test,hdf5

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,47 +1,14 @@
 # Build documentation
+# The build is uploaded as artifact if the triggering event is a push for a pull request
+# The build is published to github pages if the triggering event is a push to the master branch (PR merge)
 name: Build and upload documentation
 
-defaults:
-  run:
-    shell: bash
-
-on:  # Runs on any push event to master
+on:  # Runs on any push event in a PR or any push event to master
+  pull_request:
   push:
     branches:
       - 'master'
 
 jobs:
   documentation:
-    name: ${{ matrix.os }} / ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:  # only lowest supported Python on latest ubuntu
-        os: [ubuntu-latest]
-        python-version: [3.7]
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/setup.py'
-
-      - name: Upgrade pip, setuptools and wheel
-        run: python -m pip install --upgrade pip setuptools wheel
-
-      - name: Install package
-        run: python -m pip install '.[doc]'
-
-      - name: Build documentation
-        run: python -m sphinx -b html doc ./doc_build -d ./doc_build
-
-      - name: Upload documentation to gh-pages
-        if: ${{ success() }}
-        uses: JamesIves/github-pages-deploy-action@3.7.1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: doc_build
+        uses: pylhc/.github/.github/workflows/documentation.yml@master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,46 +1,11 @@
 # Publishes to PyPI upon creation of a release
 name: Upload Package to PyPI
 
-defaults:
-  run:
-    shell: bash
-
 on:  # Runs everytime a release is added to the repository
   release:
     types: [created]
 
 jobs:
   deploy:
-    name: ${{ matrix.os }} / ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:  # only lowest supported Python on latest ubuntu
-        os: [ubuntu-latest]
-        python-version: [3.7]
-
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/setup.py'
-
-      - name: Upgrade pip, setuptools, wheel, build and twine
-        run: python -m pip install --upgrade pip setuptools wheel build twine
-
-      - name: Build and check build
-        run: |
-          python -m build 
-          twine check dist/*
-
-      - name: Publish
-        if: ${{ success() }}
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          twine upload dist/*
+    uses: pylhc/.github/.github/workflows/publish.yml@master
+    secrets: inherit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,39 +1,17 @@
-# Runs all tests not flagged as "extended" with a pytest marker
-name: Tests
+# Runs all tests 
+name: All Tests
 
 defaults:
   run:
     shell: bash
 
-on:  [push]  # Runs on all push events to any branch
-
+on:  # Runs on any push event to any branch except master (the coverage workflow takes care of that)
+  push:
+    branches-ignore:
+      - 'master'
 
 jobs:
   tests:
-    name: ${{ matrix.os }} / ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
-        # Make sure to escape 3.10 with quotes so it doesn't get interpreted as float 3.1 by GA's parser
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/setup.py'
-
-      - name: Upgrade pip, setuptools and wheel
-        run: python -m pip install --upgrade pip setuptools wheel
-
-      - name: Install package
-        run: python -m pip install '.[test,hdf5]'
-
-      - name: Run tests
-        run: python -m pytest
+    uses: pylhc/.github/.github/workflows/tests.yml@master
+    with:
+      extra-dependencies: test,hdf5

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ DEPENDENCIES = [
 EXTRA_DEPENDENCIES = {
     "test": ["pytest>=5.2", "pytest-cov>=2.9", "cpymad>=1.8.1", "zstandard>=0.15.2"],
     "hdf5": ["h5py>=2.9.0", "tables>=3.6.0"],
-    "doc": ["sphinx<7.0", "sphinx_rtd_theme", "sphinx_copybutton", "sphinx-prompt", "sphinx_codeautolink"],
+    "doc": ["sphinx", "sphinx_rtd_theme", "sphinx_copybutton", "sphinx-prompt", "sphinx_codeautolink"],
 }
 EXTRA_DEPENDENCIES.update({"all": [elem for list_ in EXTRA_DEPENDENCIES.values() for elem in list_]})
 EXTRA_DEPENDENCIES["test"] += EXTRA_DEPENDENCIES["hdf5"]

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ DEPENDENCIES = [
 EXTRA_DEPENDENCIES = {
     "test": ["pytest>=5.2", "pytest-cov>=2.9", "cpymad>=1.8.1", "zstandard>=0.15.2"],
     "hdf5": ["h5py>=2.9.0", "tables>=3.6.0"],
-    "doc": ["sphinx", "sphinx_rtd_theme", "sphinx_copybutton", "sphinx-prompt", "sphinx_codeautolink"],
+    "doc": ["sphinx<7.0", "sphinx_rtd_theme", "sphinx_copybutton", "sphinx-prompt", "sphinx_codeautolink"],
 }
 EXTRA_DEPENDENCIES.update({"all": [elem for list_ in EXTRA_DEPENDENCIES.values() for elem in list_]})
 EXTRA_DEPENDENCIES["test"] += EXTRA_DEPENDENCIES["hdf5"]


### PR DESCRIPTION
We had issues this morning in the cron tests, and it appears we were still using the now EOL 3.7 Python.

I took the opportunity to migrate to the new common workflows from @JoschD.

This PR:
- Migrates the workflows to use the org's common ones
- Removes 3.7 from matrices in the same go.

@JoschD it would be nice if you can check I used the correct syntax, specifically when indicating the extra test dependencies (in both `cron` and `tests` workflows).