### PR TITLE
Pandas dependency version restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # TFS-Pandas Changelog
 
+## Version 3.7.1
+
+- Changed:
+    - The dependency on `pandas` was restricted to avoid the latest version (and above, for now) as a temporary workaround to an attribute access bug that arose with it. 
+
 ## Version 3.7.0
 
 Minor API changes to the `TFSCollections`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 3.7.1
 
 - Changed:
-    - The dependency on `pandas` was restricted to avoid the latest version (and above, for now) as a temporary workaround to an attribute access bug that arose with it. 
+    - The dependency on `pandas` was restricted to avoid the latest version, `2.1.0` and above as a temporary workaround to an attribute access bug that arose with it. 
 
 ## Version 3.7.0
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ with README.open("r") as docs:
 # Dependencies for the package itself
 DEPENDENCIES = [
     "numpy>=1.19.0",
-    "pandas>=1.0",
+    "pandas>=1.0,<2.1.0",
 ]
 
 # Extra dependencies

--- a/tfs/__init__.py
+++ b/tfs/__init__.py
@@ -10,7 +10,7 @@ from tfs.writer import write_tfs
 __title__ = "tfs-pandas"
 __description__ = "Read and write tfs files."
 __url__ = "https://github.com/pylhc/tfs"
-__version__ = "3.7.0"
+__version__ = "3.7.1"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"


### PR DESCRIPTION
As stated in the changelog in this PR, this restricts to `pandas<2.1.0` which is a new version that led to an attribute access bug for us.

This is for a patch release that prevents installing the problematic `pandas` version(s) while we investigate with the `pandas` devs. Should also help our CI builds failing left and right.