### PR TITLE
CI Fix

### DIFF
--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -321,7 +321,7 @@ def _dataframe_empty_headers() -> TfsDataFrame:
 @pytest.fixture()
 def _messed_up_dataframe() -> TfsDataFrame:
     """Returns a TfsDataFrame with mixed types in each column, some elements being lists."""
-    int_row = numpy.array([random.randint(-1e5, 1e5) for _ in range(4)], dtype=numpy.float64)
+    int_row = numpy.array([random.randint(int(-1e5), int(1e5)) for _ in range(4)], dtype=numpy.float64)
     float_row = numpy.array([round(random.uniform(-1e5, 1e5), 7) for _ in range(4)], dtype=numpy.float64)
     string_row = numpy.array([_rand_string() for _ in range(4)], dtype=str)
     list_floats_row = [[1.0, 14.777], [2.0, 1243.9], [3.0], [123414.0, 9909.12795]]
@@ -336,7 +336,7 @@ def _messed_up_dataframe() -> TfsDataFrame:
 @pytest.fixture()
 def _dict_column_in_dataframe() -> TfsDataFrame:
     """Returns a TfsDataFrame with a column having dictionaries as elements."""
-    int_elements = [random.randint(-1e5, 1e5) for _ in range(4)]
+    int_elements = [random.randint(int(-1e5), int(1e5)) for _ in range(4)]
     float_elements = [round(random.uniform(-1e5, 1e5), 7) for _ in range(4)]
     string_elements = [_rand_string() for _ in range(4)]
     dict_elements = [{"a": "dict"}, {"b": 14}, {"c": 444.12}, {"d": [1, 2]}]
@@ -352,7 +352,7 @@ def _dict_column_in_dataframe() -> TfsDataFrame:
 @pytest.fixture()
 def _list_column_in_dataframe() -> TfsDataFrame:
     """Returns a TfsDataFrame with a column having lists as elements."""
-    int_elements = [random.randint(-1e5, 1e5) for _ in range(4)]
+    int_elements = [random.randint(int(-1e5), int(1e5)) for _ in range(4)]
     float_elements = [round(random.uniform(-1e5, 1e5), 7) for _ in range(4)]
     string_elements = [_rand_string() for _ in range(4)]
     list_elements = [[1.0, 14.777], [2.0, 1243.9], [3.0], [123414.0, 9909.12795]]


### PR DESCRIPTION
In the cron jobs, in Python 3.12 having floats in `random.randint` args raised an error.