### PR TITLE
Deprecations and FutureWarnings Fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ with README.open("r") as docs:
 # Dependencies for the package itself
 DEPENDENCIES = [
     "numpy>=1.19.0",
-    "pandas>=2.0",
+    "pandas>=2.1",
 ]
 
 # Extra dependencies

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setuptools.setup(
     url=ABOUT_TFS["__url__"],
     packages=setuptools.find_packages(include=(MODULE_NAME,)),
     include_package_data=True,
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     license=ABOUT_TFS["__license__"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ with README.open("r") as docs:
 # Dependencies for the package itself
 DEPENDENCIES = [
     "numpy>=1.19.0",
-    "pandas>=1.0",
+    "pandas>=2.0",
 ]
 
 # Extra dependencies

--- a/tfs/__init__.py
+++ b/tfs/__init__.py
@@ -10,7 +10,7 @@ from tfs.writer import write_tfs
 __title__ = "tfs-pandas"
 __description__ = "Read and write tfs files."
 __url__ = "https://github.com/pylhc/tfs"
-__version__ = "3.7.3"
+__version__ = "3.8.0"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/tfs/__init__.py
+++ b/tfs/__init__.py
@@ -10,7 +10,7 @@ from tfs.writer import write_tfs
 __title__ = "tfs-pandas"
 __description__ = "Read and write tfs files."
 __url__ = "https://github.com/pylhc/tfs"
-__version__ = "3.7.2"
+__version__ = "3.7.3"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/tfs/__init__.py
+++ b/tfs/__init__.py
@@ -19,4 +19,4 @@ __license__ = "MIT"
 read = read_tfs
 write = write_tfs
 
-__all__ = [concat, read, write, read_hdf, write_hdf, TfsDataFrame, __version__]
+__all__ = ["concat", "read", "write", "read_hdf", "write_hdf", "TfsDataFrame", "TfsFormatError", "__version__"]

--- a/tfs/collection.py
+++ b/tfs/collection.py
@@ -4,7 +4,7 @@ Collection
 
 Advanced **TFS** files reading and writing functionality.
 """
-from typing import Tuple, List, Dict
+from typing import Tuple, Dict
 
 import pathlib
 

--- a/tfs/frame.py
+++ b/tfs/frame.py
@@ -264,9 +264,12 @@ def validate(
 
     # -----  Check that no element is non-physical value in the dataframe ----- #
     # The pd.option_context('mode.use_inf_as_na', True) context manager raises FutureWarning
-    # and will likely disappear in pandas 3.0 so we replaced inf values by NaNs before calling
-    # .isna(). Since .replace() returns a copy we're not modifying the original dataframe.
-    inf_or_nan_bool_df = data_frame.replace([np.inf, -np.inf], np.nan).isna()  # 
+    # and will likely disappear in pandas 3.0 so we replace 'inf' values by NaNs before calling
+    # .isna(). Additionally, the downcasting behaviour of .replace() is deprecated and raises a
+    # FutureWarning, so we use .infer_objects() first to attemps soft conversion to a better dtype
+    # for object-dtype columns (which strings can be). Since .infer_objects() and .replace() return
+    # (lazy for the former) copies we're not modifying the original dataframe during validation :)
+    inf_or_nan_bool_df = data_frame.infer_objects().replace([np.inf, -np.inf], np.nan).isna()
 
     if inf_or_nan_bool_df.to_numpy().any():
         LOGGER.warning(

--- a/tfs/frame.py
+++ b/tfs/frame.py
@@ -263,8 +263,10 @@ def validate(
         raise TfsFormatError("Lists or tuple elements are not accepted in a TfsDataFrame")
 
     # -----  Check that no element is non-physical value in the dataframe ----- #
-    with pd.option_context('mode.use_inf_as_na', True):
-        inf_or_nan_bool_df = data_frame.isna()
+    # The pd.option_context('mode.use_inf_as_na', True) context manager raises FutureWarning
+    # and will likely disappear in pandas 3.0 so we replaced inf values by NaNs before calling
+    # .isna(). Since .replace() returns a copy we're not modifying the original dataframe.
+    inf_or_nan_bool_df = data_frame.replace([np.inf, -np.inf], np.nan).isna()  # 
 
     if inf_or_nan_bool_df.to_numpy().any():
         LOGGER.warning(

--- a/tfs/reader.py
+++ b/tfs/reader.py
@@ -135,7 +135,7 @@ def read_tfs(
         tfs_file_path,
         engine="c",  # faster, and we do not need the features of the python engine
         skiprows=metadata.non_data_lines,  # no need to read these lines again
-        delim_whitespace=True,  # understands ' ' is our delimiter
+        sep="\s+",  # understands ' ' is our delimiter | replaced use of deprecated 'delim_whitespace' option in 3.8.0
         skipinitialspace=True,  # understands ' ' and '     ' are both valid delimiters
         quotechar='"',  # elements surrounded by " are one entry -> correct parsing of strings with spaces
         names=metadata.column_names,  # column names we have determined, avoids using first read row for columns

--- a/tfs/reader.py
+++ b/tfs/reader.py
@@ -135,8 +135,7 @@ def read_tfs(
         tfs_file_path,
         engine="c",  # faster, and we do not need the features of the python engine
         skiprows=metadata.non_data_lines,  # no need to read these lines again
-        sep="\s+",  # understands ' ' as delimiter | replaced deprecated 'delim_whitespace' in tfs-pandas 3.8.0
-        skipinitialspace=True,  # allow to skip spaces after delimiter (understands ' ' and '     ' are both valid delimiters)
+        sep=r"\s+",  # understands ' ' as delimiter | replaced deprecated 'delim_whitespace' in tfs-pandas 3.8.0
         quotechar='"',  # elements surrounded by " are one entry -> correct parsing of strings with spaces
         names=metadata.column_names,  # column names we have determined, avoids using first read row for columns
         dtype=dict(

--- a/tfs/reader.py
+++ b/tfs/reader.py
@@ -135,8 +135,8 @@ def read_tfs(
         tfs_file_path,
         engine="c",  # faster, and we do not need the features of the python engine
         skiprows=metadata.non_data_lines,  # no need to read these lines again
-        sep="\s+",  # understands ' ' is our delimiter | replaced use of deprecated 'delim_whitespace' option in 3.8.0
-        skipinitialspace=True,  # understands ' ' and '     ' are both valid delimiters
+        sep="\s+",  # understands ' ' as delimiter | replaced deprecated 'delim_whitespace' in tfs-pandas 3.8.0
+        skipinitialspace=True,  # allow to skip spaces after delimiter (understands ' ' and '     ' are both valid delimiters)
         quotechar='"',  # elements surrounded by " are one entry -> correct parsing of strings with spaces
         names=metadata.column_names,  # column names we have determined, avoids using first read row for columns
         dtype=dict(

--- a/tfs/writer.py
+++ b/tfs/writer.py
@@ -236,7 +236,7 @@ def _quote_string_columns(data_frame: Union[TfsDataFrame, pd.DataFrame]) -> Unio
                 return f'"{s}"'
         return s
 
-    data_frame = data_frame.applymap(quote_strings)
+    data_frame = data_frame.map(quote_strings)
     return data_frame
 
 


### PR DESCRIPTION
This PR brings changes to address the two deprecations / warnings which aren't very far away from being actual issues. I have bumped the package version as a patch, but this can be discussed.

## Deprecated use of `.applymap`

The call to [`.applymap`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.applymap.html) in `tfs.writer._quote_string_columns` has been changed to [`.map`](http://pandas.pydata.org/docs/reference/api/pandas.DataFrame.map.html) (a total equivalent) since `.applymap` is deprecated and will be removed in (most likely) the next major `pandas` version.

- Following this, the minimum required version of `pandas` in the package has been upped to `2.1` which is where `.map` appeared (and `.applymap` was deprecated).
- Accordingly, since `Python 3.8` is not supported by `pandas 2.1` I have increased `tfs`'s minimum required Python version to `3.9`. Considering `3.8` no longer gets active support and will stop receiving security updates within the second half of the year, I don't think this is too extreme. More thoughts on the timeline below.

## Deprecated use of `delim_whitespace` in `pd.read_csv` when reading

The `delim_whitespace` option is now deprecated. A simple fix was to use `sep="\s+"` as suggested in the issued warning. The option has been around for a long time and comes with no version / timeline considerations.

## FutureWarning from `pd.option_context('mode.use_inf_as_na', True)`

The use of the `pd.option_context('mode.use_inf_as_na', True)` context manager in `tfs.frame.validate` raises a `FutureWarning` which recommends to convert instead. It's not clear from the warning when this functionality will stop being supported.

To circumvent this, the `.isna()` call is now made after calling [`.replace([np.inf, -np.inf], np.nan)`](http://pandas.pydata.org/docs/reference/api/pandas.DataFrame.replace.html). Since `.replace` returns a copy we are not modifying the provided dataframe. Comments have been added above the relevant code for developpers.

According to the accepted answer in [this StackOverflow thread](https://stackoverflow.com/questions/66922511/replace-all-inf-inf-values-with-nan-in-a-pandas-dataframe), the performance impact should be quite small: about 0.1s on a dataframe with 1M rows (and most likely faster on newer Python versions since the `.replace` [source code](https://github.com/pandas-dev/pandas/blob/v2.1.4/pandas/core/generic.py#L7680-L7921) uses a lot of native Python). Could be compared with the runtime impact of the current `with pd.option_context('mode.use_inf_as_na', True)` call, through the impact seems small enought that I did not benchmark.

## FutureWarning from `.replace([np.inf, -np.inf], np.nan)`

The above change now also raises a future warning about object downcasting during the operation. A fix is done by first calling `.infer_dtypes()` on the dataframe to infer types where possible as suggested in the issued warning. This call creates a lazy copy (for copy-on-write behaviour that will come in `pandas 3.0` but the following call to `.replace()` creates a hard copy which erases all concerns about changing the original dataframe during validation. The `.infer_dtypes()` function has been around for a long time and comes with no version / timeline considerations.

## Suggested Timeline

I suggest we leave this PR as a draft for now. According to [the pandas repo](https://github.com/pandas-dev/pandas/milestone/102), `pandas 3.0` is due for April 1st, 2024 and we will most likely encounter issues with the current `tfs-pandas` code at this time. 

By then, `Python 3.8` support will be [6 months away from complete end of life](https://endoflife.date/python) and I believe it will be reasonable to simply drop support for it ourselves (which merging this PR and publishing will do).

In short: if we want to be conservative with our supported Python versions, we should keep this PR open until just before `pandas 3.0` comes around (~ April), and merge + publish a new version of `tfs-pandas` then. Otherwise we can merge and publish sooner.

### Note on CI

The CI is currently messed up since we have `Python 3.8` in our tests matrix and the package, in this branch, can't install on this version (since we ask for `pandas >= 2.1` which does not exist for `Python 3.8`).

If we're waiting until close to April to merge and drop `Python 3.8` support, we could at the same time remove it from our CI matrices.