### PR TITLE
Maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # TFS-Pandas
 
-[![Cron Testing](https://github.com/pylhc/tfs/workflows/Cron%20Testing/badge.svg)](https://github.com/pylhc/tfs/actions?query=workflow%3A%22Cron+Testing%22)
-[![Code Climate coverage](https://img.shields.io/codeclimate/coverage/pylhc/tfs.svg?style=popout)](https://codeclimate.com/github/pylhc/tfs)
-[![Code Climate maintainability (percentage)](https://img.shields.io/codeclimate/maintainability-percentage/pylhc/tfs.svg?style=popout)](https://codeclimate.com/github/pylhc/tfs)
-<!-- [![GitHub last commit](https://img.shields.io/github/last-commit/pylhc/tfs.svg?style=popout)](https://github.com/pylhc/tfs/) -->
+[![Tests](https://github.com/pylhc/tfs/actions/workflows/coverage.yml/badge.svg?branch=master)](https://github.com/pylhc/tfs/actions/workflows/coverage.yml)
+[![GitHub last commit](https://img.shields.io/github/last-commit/pylhc/tfs.svg?style=popout)](https://github.com/pylhc/tfs/)
 [![GitHub release](https://img.shields.io/github/v/release/pylhc/tfs?logo=github)](https://github.com/pylhc/tfs/)
 [![PyPI Version](https://img.shields.io/pypi/v/tfs-pandas?label=PyPI&logo=pypi)](https://pypi.org/project/tfs-pandas/)
 [![Conda-forge Version](https://img.shields.io/conda/vn/conda-forge/tfs-pandas?color=orange&logo=anaconda)](https://anaconda.org/conda-forge/tfs-pandas)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -89,8 +90,12 @@ changelog = "https://github.com/pylhc/tfs/blob/master/CHANGELOG.md"
 # ----- Tests Configuration ----- #
 
 [tool.pytest.ini_options]
-addopts = "--cov-report=xml --cov-report term-missing --cov-config=pyproject.toml --cov=tfs"
-testpaths = ["tests"]
+addopts = [
+    "--import-mode=importlib",
+]
+
+[tool.coverage.run]
+relative_files = true
 
 [tool.coverage.report]
 exclude_also = [


### PR DESCRIPTION
Add coverage config options (as done in `omc3`), remove CodeClimate and update coverage badge on readme.

No version bump since `tfs` has already dropped `Python 3.9`. This is just a simple merge.

Note: can't run tests on `3.14` since Pytables have yet to release wheels.
