### PR TITLE
Madng features guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # TFS-Pandas Changelog
 
+## Version 4.0.1
+
+- Fixed:
+  - Fixed an issue where writing a `TfsDataFrame` to disk in the `HDF5` format would crash if the provided file path was a string.
+
+- Changed:
+  - Some type hints have been fixed or improved in parts of the codebase.
+
+- Documentation:
+  - Added information on how to handle `MAD-NG`'s specific features via `pymadng` when reading and writing `TFS` files in the documentation.
+
 ## Version 4.0.0
 
 Version `4.0` is a major release bringing compatibility with `MAD-NG` features in **TFS** files and tables, apart from the more exotic ones.
@@ -71,12 +82,12 @@ Please have a look at the documentation should you intent to use `tfs-pandas` 4.
 ## Version 3.7.3
 
 - Fixed:
-  - Fixed a regression where the writing of a `pd.Series`-like object to disk was raising an error. It is now possible again.  
+  - Fixed a regression where the writing of a `pd.Series`-like object to disk was raising an error. It is now possible again.
 
 ## Version 3.7.2
 
 - Fixed:
-  - fixing the issues with `pandas` >= `v2.1.0` (see `tfs-pandas` `v3.7.1`) by overwriting the `_constructor_from_mgr` function.  
+  - fixing the issues with `pandas` >= `v2.1.0` (see `tfs-pandas` `v3.7.1`) by overwriting the `_constructor_from_mgr` function.
 
 ## Version 3.7.1
 
@@ -168,7 +179,7 @@ Minor API changes to the `TFSCollections`:
 
 - Added:
   - HDF5 read/write.
-  
+
 - Changed:
   - The minimum required Python version is now `3.7`.
 

--- a/doc/compatibility.rst
+++ b/doc/compatibility.rst
@@ -85,6 +85,25 @@ Namely, the following are accepted by ``MAD-NG`` and ``MAD-NG`` only:
     One can find information on table writing for ``MAD-NG`` in `their documentation pages <https://madx.web.cern.ch/releases/madng/html/mad_gen_mtable.html>`_.
 
     Should one need to use these features, it is recommended to go through the `pymadng <https://pymadng.readthedocs.io/en/latest/>`_ package to handle them in-memory.
+    Below is an example of how to read a **TFS** file including a ``Lua`` table in its headers with ``pymadng`` and extract the `TfsDataFrame`.
+    The header line would look like:
+
+    .. code-block::
+
+        @ trkrdt             %03t     {"f4000", "f2020", "f3100"}
+
+    The file can be read via ``pymadng`` and converted as follows (please note the need to double quote the file name):
+
+    .. code-block:: python
+
+        from pymadng import MAD
+
+        mad = MAD()
+        df = mad.mtable.read("'madng_tfs_file.tfs'").eval().to_df()
+
+        print(type(df))  # prints: <class 'tfs.frame.TfsDataFrame'>
+        print(df.headers["trkrdt"])  # prints: ['f4000', 'f2020', 'f3100']
+
 
 .. _madx mode:
 

--- a/doc/compatibility.rst
+++ b/doc/compatibility.rst
@@ -81,6 +81,9 @@ Namely, the following are accepted by ``MAD-NG`` and ``MAD-NG`` only:
 .. attention::
 
     The exotic "features" of ``MAD-NG`` such as the ``Lua`` operator overloading for ranges and tables, and their inclusion in **TFS** files are not supported by `tfs-pandas`.
+    We firstly recommend users only include these if truly needed, and avoid writing them out otherwise.
+    One can find information on table writing for ``MAD-NG`` in `their documentation pages <https://madx.web.cern.ch/releases/madng/html/mad_gen_mtable.html>`_.
+
     Should one need to use these features, it is recommended to go through the `pymadng <https://pymadng.readthedocs.io/en/latest/>`_ package to handle them in-memory.
 
 .. _madx mode:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -87,7 +87,7 @@ todo_include_todos = True
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = ".rst"
+source_suffix = {".rst": "restructuredtext"}
 
 # The master toctree document.
 master_doc = "index"
@@ -139,8 +139,9 @@ html_theme = "sphinx_rtd_theme"
 
 html_theme_options = {
     "collapse_navigation": False,
-    "version_selector": True,  # replaces 'display_version' since sphinx-rtd-theme 3.0 but only works on ReadTheDocs
-    "logo_only": True,
+    #'display_version': True,  # show version in the sidebar (currently not working: https://github.com/readthedocs/sphinx_rtd_theme/issues/1624)
+    # "version_selector": True,  # replaces 'display_version' since sphinx-rtd-theme 3.0 but only works on ReadTheDocs
+    "logo_only": True,  # if True, display only logo image, no project name
     "navigation_depth": 3,
 }
 
@@ -156,12 +157,6 @@ html_context = {
 html_css_files = ["css/custom.css"]
 
 smartquotes_action = "qe"  # renders only quotes and ellipses (...) but not dashes (option: D)
-
-# Theme options are theme-specific and customize the look and feel of a theme
-# further.  For a list of options available for each theme, see the
-# documentation.
-#
-# html_theme_options = {}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -184,6 +179,24 @@ html_sidebars = {
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = "tfspandasdoc"
+
+# -- Autodoc options ------------------------------------------------------
+
+# This is to tell Sphinx how to print some specific type annotations
+# See: https://stackoverflow.com/a/67483317
+# See: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_type_aliases
+autodoc_type_aliases = {"ArrayLike": "ArrayLike"}
+
+autodoc_default_options = {
+    "members": True,  # include members
+    "undoc-members": True,  # add all members, even if they have no docstring
+    "show-inheritance": True,  # e.g. ``class LHC(Accelerator)`` shows ``BaseClass: Accelerator``
+    # "no-index-entry": True,  # don't add an index entry (toc_object_entries below works better for our use case)
+}
+
+toc_object_entries = (
+    False  # do not create entries for domain objects (e.g. functions, classes, attributes, etc.).
+)
 
 # -- Options for LaTeX output ---------------------------------------------
 

--- a/doc/modules/index.rst
+++ b/doc/modules/index.rst
@@ -2,45 +2,19 @@ API Reference
 =============
 
 .. automodule:: tfs.collection
-    :members:
-    :noindex:
-
 
 .. automodule:: tfs.constants
-    :members:
-    :noindex:
-
 
 .. automodule:: tfs.errors
-    :members:
-    :noindex:
-
 
 .. automodule:: tfs.frame
-    :members:
-    :noindex:
-
 
 .. automodule:: tfs.hdf
-    :members:
-    :noindex:
-
 
 .. automodule:: tfs.reader
-    :members:
-    :noindex:
-
 
 .. automodule:: tfs.testing
-    :members:
-    :noindex:
-
 
 .. automodule:: tfs.tools
-    :members:
-    :noindex:
-
 
 .. automodule:: tfs.writer
-    :members:
-    :noindex:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ test = [
   "tfs-pandas[hdf5]",
   "pytest >= 7.0",
   "pytest-cov >= 2.9",
-  "cpymad >= 1.8.1",  # to check MAD-X can read our files
+  "cpymad >= 1.19.0",  # to check MAD-X can read our files
   "pymadng >= 0.6.0",  # to check MAD-NG can read our files
 ]
 doc = [

--- a/tests/test_hdf.py
+++ b/tests/test_hdf.py
@@ -18,6 +18,20 @@ class TestHDF:
         df_read = read_hdf(out_file)
         assert_tfs_frame_equal(_tfs_dataframe, df_read)
 
+    def test_read_write_string_path(self, tmp_path: Path, _tfs_dataframe: TfsDataFrame):
+        """
+        Basic read-write loop test for TfsDataFrames to hdf5 format.
+        This time the provided file path is a string.
+        """
+        out_file = str(tmp_path / "data_frame.h5")# use string path instead of Path object
+        write_hdf(out_file, _tfs_dataframe)
+
+        assert Path(out_file).is_file()
+
+        df_read = read_hdf(out_file)
+        assert_tfs_frame_equal(_tfs_dataframe, df_read)
+
+
     def test_read_write_madng_features(self, _tfs_madng_file, tmp_path):
         """Same as the above for a dataframe which includes MAD-NG features."""
         original = read_tfs(_tfs_madng_file)

--- a/tfs/__init__.py
+++ b/tfs/__init__.py
@@ -11,7 +11,7 @@ from tfs.writer import write_tfs
 __title__ = "tfs-pandas"
 __description__ = "Read and write tfs files."
 __url__ = "https://github.com/pylhc/tfs"
-__version__ = "4.0.0"
+__version__ = "4.0.1"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/tfs/constants.py
+++ b/tfs/constants.py
@@ -5,7 +5,7 @@ Constants
 General constants used throughout ``tfs-pandas``, relating to the standard of **TFS** files.
 """
 
-from __future__ import annotations
+from __future__ import annotations  # for delayed type annotations
 
 from types import NoneType
 

--- a/tfs/errors.py
+++ b/tfs/errors.py
@@ -5,7 +5,12 @@ Errors
 Errors that can be raised during the handling of **TFS** files.
 """
 
-from pathlib import Path
+from __future__ import annotations  # for delayed type annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # ----- Main Exception to Inherit From ----- #
 

--- a/tfs/frame.py
+++ b/tfs/frame.py
@@ -6,7 +6,7 @@ Contains the class definition of a ``TfsDataFrame``, inherited from the ``pandas
 as a utility function to validate the correctness of a ``TfsDataFrame``.
 """
 
-from __future__ import annotations
+from __future__ import annotations  # for delayed type annotations
 
 import logging
 from contextlib import suppress

--- a/tfs/hdf.py
+++ b/tfs/hdf.py
@@ -5,7 +5,7 @@ HDF5 I/O
 Additional tools for reading and writing ``TfsDataFrames`` into ``hdf5`` files.
 """
 
-from __future__ import annotations
+from __future__ import annotations  # for delayed type annotations
 
 import contextlib
 import logging

--- a/tfs/hdf.py
+++ b/tfs/hdf.py
@@ -9,24 +9,21 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pandas as pd
 
 from tfs import TfsDataFrame
 
-if TYPE_CHECKING:
-    from pathlib import Path
-
 try:
     import h5py
 except ImportError:
-    h5py = None
+    h5py = None  # ty:ignore[invalid-assignment]
 
 try:
     import tables
 except ImportError:
-    tables = None
+    tables = None  # ty:ignore[invalid-assignment]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -56,6 +53,7 @@ def write_hdf(path: Path | str, df: TfsDataFrame, **kwargs) -> None:
     # Check for `mode` kwarg (allowed under circumstances but generally ignored) ---
     user_mode = kwargs.pop("mode", None)
     if user_mode is not None and user_mode != "w":
+        path = Path(path)
         if path.exists():
             errmsg = (
                 f"'mode=\"{user_mode}\"' is not allowed here."

--- a/tfs/reader.py
+++ b/tfs/reader.py
@@ -5,7 +5,7 @@ Reader
 Reading functionalty for **TFS** files.
 """
 
-from __future__ import annotations
+from __future__ import annotations  # for delayed type annotations
 
 import logging
 import pathlib

--- a/tfs/reader.py
+++ b/tfs/reader.py
@@ -344,7 +344,7 @@ def _read_metadata(tfs_file_path: pathlib.Path | str) -> _TfsMetaData:
     )
 
 
-def _parse_header_line(str_list: list[str]) -> tuple[str, bool | str | int | float, np.complex128]:
+def _parse_header_line(str_list: list[str]) -> tuple[str, bool | str | int | float | np.complex128]:
     """
     Parses the data in the provided header line. Expects a valid header
     line starting with the '@' identifier, and parses the content that

--- a/tfs/reader.py
+++ b/tfs/reader.py
@@ -319,8 +319,7 @@ def _read_metadata(tfs_file_path: pathlib.Path | str) -> _TfsMetaData:
     # and provides and handle to iterate through, line by line
     with _metadata_handle(tfs_file_path) as file_reader:
         for line_number, line in enumerate(file_reader):
-            stripped_line = line.strip()
-            if not stripped_line:
+            if not (stripped_line := line.strip()):
                 continue  # empty line
             line_components = shlex.split(stripped_line)
             if line_components[0] == HEADER:

--- a/tfs/reader.py
+++ b/tfs/reader.py
@@ -346,7 +346,7 @@ def _read_metadata(tfs_file_path: pathlib.Path | str) -> _TfsMetaData:
     )
 
 
-def _parse_header_line(str_list: list[str]) -> tuple[str, bool | str | int | float | np.complex128]:
+def _parse_header_line(str_list: list[str]) -> tuple[str, bool | str | int | float | np.complex128 | None]:
     """
     Parses the data in the provided header line. Expects a valid header
     line starting with the '@' identifier, and parses the content that

--- a/tfs/reader.py
+++ b/tfs/reader.py
@@ -207,10 +207,10 @@ def read_tfs(
 
     if index:
         LOGGER.debug(f"Setting '{index}' column as index")
-        tfs_data_frame = tfs_data_frame.set_index(index)
+        tfs_data_frame: TfsDataFrame = tfs_data_frame.set_index(index)  # ty:ignore[invalid-assignment]
     else:
         LOGGER.debug("Attempting to find index identifier in columns")
-        tfs_data_frame = _find_and_set_index(tfs_data_frame)
+        tfs_data_frame: TfsDataFrame = _find_and_set_index(tfs_data_frame)
 
     # Only perform validation if asked ('validate' defaults to None which skips this step)
     if validate is not None:  # validation function checks for valid values

--- a/tfs/reader.py
+++ b/tfs/reader.py
@@ -318,7 +318,7 @@ def _read_metadata(tfs_file_path: pathlib.Path | str) -> _TfsMetaData:
     # Note: the helper contextmanager handles compression for us
     # and provides and handle to iterate through, line by line
     with _metadata_handle(tfs_file_path) as file_reader:
-        for line_number, line in enumerate(file_reader.readlines()):
+        for line_number, line in enumerate(file_reader):
             stripped_line = line.strip()
             if not stripped_line:
                 continue  # empty line

--- a/tfs/reader.py
+++ b/tfs/reader.py
@@ -410,12 +410,14 @@ def _find_and_set_index(data_frame: TfsDataFrame) -> TfsDataFrame:
     return data_frame
 
 
-def _compute_column_types(str_list: list[str]) -> list[type]:
+def _compute_column_types(identifiers: list[str]) -> list[type]:
     """
     Returns the data type for each column based on the
-    corresponding provided type identifier strings.
+    corresponding provided type identifier strings. The
+    type identifier strings are written on the line just
+    below the column names (the %le, %d, %s, etc.).
     """
-    return [_id_to_type(string) for string in str_list]
+    return [_id_to_type(type_id) for type_id in identifiers]
 
 
 def _string_to_bool(val_str: str) -> bool:

--- a/tfs/reader.py
+++ b/tfs/reader.py
@@ -330,7 +330,7 @@ def _read_metadata(tfs_file_path: pathlib.Path | str) -> _TfsMetaData:
                 column_names = np.array(line_components[1:])
             elif line_components[0] == TYPES:
                 LOGGER.debug("Parsing column types.")
-                column_types = _compute_types(line_components[1:])
+                column_types = _compute_column_types(line_components[1:])
             elif line_components[0] == COMMENTS:
                 continue
             else:  # After all previous cases should only be data lines. If not, file is fucked.
@@ -406,7 +406,11 @@ def _find_and_set_index(data_frame: TfsDataFrame) -> TfsDataFrame:
     return data_frame
 
 
-def _compute_types(str_list: list[str]) -> list[type]:
+def _compute_column_types(str_list: list[str]) -> list[type]:
+    """
+    Returns the data type for each column based on the
+    corresponding provided type identifier strings.
+    """
     return [_id_to_type(string) for string in str_list]
 
 

--- a/tfs/reader.py
+++ b/tfs/reader.py
@@ -44,6 +44,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from io import TextIOWrapper
 
+    from pandas import DataFrame
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -183,7 +185,7 @@ def read_tfs(
 
     # DO NOT use `comment=COMMENTS` in this call: if the '#' symbol is in an element (a
     # string header or some value in the dataframe) then the entire parsing will crash
-    data_frame = pd.read_csv(
+    data_frame: DataFrame = pd.read_csv(  # ty:ignore[no-matching-overload]
         tfs_file_path,
         sep=r"\s+",  # understands ' ' as delimiter | replaced deprecated 'delim_whitespace' in tfs-pandas 3.8.0
         names=metadata.column_names,  # column names we have determined, avoids using first read row for columns

--- a/tfs/reader.py
+++ b/tfs/reader.py
@@ -402,7 +402,7 @@ def _find_and_set_index(data_frame: TfsDataFrame) -> TfsDataFrame:
     """
     index_column = [colname for colname in data_frame.columns if colname.startswith(INDEX_ID)]
     if index_column:
-        data_frame = data_frame.set_index(index_column)
+        data_frame: TfsDataFrame = data_frame.set_index(index_column)  # ty:ignore[invalid-assignment]
         index_name = index_column[0].replace(INDEX_ID, "")
         if index_name == "":
             index_name = None  # to remove it completely (Pandas makes a difference)

--- a/tfs/reader.py
+++ b/tfs/reader.py
@@ -364,7 +364,11 @@ def _parse_header_line(str_list: list[str]) -> tuple[str, bool | str | int | flo
         InvalidBooleanHeaderError: if the identifier type indicates a boolean
             but the corresponding value is not an accepted boolean.
     """
-    type_index = next((index for index, part in enumerate(str_list) if part.startswith("%")), None)
+    # Find the index of elements at which the type identifier is located
+    # For instance for ['q2', '%le', '60.31999175'] this would be 1
+    type_index: int | None = next(
+        (index for index, part in enumerate(str_list) if part.startswith("%")), None
+    )
     if type_index is None:
         raise AbsentTypeIdentifierError(str_list)
 

--- a/tfs/reader.py
+++ b/tfs/reader.py
@@ -185,15 +185,15 @@ def read_tfs(
     # string header or some value in the dataframe) then the entire parsing will crash
     data_frame = pd.read_csv(
         tfs_file_path,
-        engine="c",  # faster, and we do not need the features of the python engine
-        skiprows=metadata.non_data_lines,  # no need to read these lines again
         sep=r"\s+",  # understands ' ' as delimiter | replaced deprecated 'delim_whitespace' in tfs-pandas 3.8.0
-        quotechar='"',  # elements surrounded by " are one entry -> correct parsing of strings with spaces
         names=metadata.column_names,  # column names we have determined, avoids using first read row for columns
         dtype=dtypes_dict,  # assign types at read-time to avoid conversions later
+        engine="c",  # faster, and we do not need the features of the python engine
         converters=converters,  # more involved dtype conversion, e.g. for complex columns
+        skiprows=metadata.non_data_lines,  # no need to read these lines again
         na_values=_NA_VALUES,  # includes MAD-NG's 'nil' which we cast to NaN in the data
         keep_default_na=False,  # we provided the list ourselves so it does not include ""
+        quotechar='"',  # elements surrounded by " are one entry -> correct parsing of strings with spaces
     )
 
     LOGGER.debug("Converting to TfsDataFrame")

--- a/tfs/testing.py
+++ b/tfs/testing.py
@@ -5,7 +5,7 @@ Testing
 Testing functionalty for TfsDataFrames.
 """
 
-from __future__ import annotations
+from __future__ import annotations  # for delayed type annotations
 
 from typing import TYPE_CHECKING
 

--- a/tfs/tools.py
+++ b/tfs/tools.py
@@ -47,7 +47,7 @@ def significant_digits(
         f"{round(error, digits):.{max(digits, 0)}f}",
     )
     if return_floats:
-        return tuple([float(val) for val in res])
+        return float(res[0]), float(res[1])
     return res
 
 

--- a/tfs/tools.py
+++ b/tfs/tools.py
@@ -5,7 +5,7 @@ Tools
 Additional functions to modify **TFS** files.
 """
 
-from __future__ import annotations
+from __future__ import annotations  # for delayed type annotations
 
 import logging
 from pathlib import Path

--- a/tfs/writer.py
+++ b/tfs/writer.py
@@ -142,7 +142,7 @@ def write_tfs(
     # would be transformed into <pd.NA> and if we write this to file we are very much cooked.)
     # Overall we do not care to infer specialized dtypes, just that it makes the best inference
     # to valid dtypes (i.e. an object column should be inferred as strings if that makes sense).
-    data_frame = data_frame.convert_dtypes(convert_integer=False, convert_floating=False, convert_string=None)
+    data_frame = data_frame.convert_dtypes(convert_integer=False, convert_floating=False, convert_string=False)
 
     if save_index:
         left_align_first_column = True

--- a/tfs/writer.py
+++ b/tfs/writer.py
@@ -5,7 +5,7 @@ Writer
 Writing functionalty for **TFS** files.
 """
 
-from __future__ import annotations
+from __future__ import annotations  # for delayed type annotations
 
 import logging
 import pathlib


### PR DESCRIPTION
This is our preferred approach to closing https://github.com/pylhc/tfs/issues/140

## Main Content

I have added in the following to the `compatibility` documentation page, in the admonition about `MAD-NG`'s unsupported features:

- Recommendation to only export what is needed via `MAD-NG`, with a link to the relevant documentation
- An example of an unsupported header line and a Python snippet for how to read the file via `pymadng` and convert it to a `tfs.frame.TfsDataFrame`.

Thanks to @jgray-19 who provided both the link and the snippet.

## Bug Fix

The following little bug was noticed by `ty` and fixed:

- The function for writing a `TfsDataFrame` to disk as `HDF5` format would crash if the provided path was a string (as declared accepted in the parameters). This is because we would use the provided variable directly as if it was a `pathlib.Path`. It was fixed by casting to `Path`. I have added a test for the case.

For this reason I've bumped the version to `4.0.1` and entered a few things in the changelog.

## Additional Content

There are a little more changes here and there:

- I've added the documentation configuration fixes for the "noindex" issue, as was solved by @JoschD in https://github.com/pylhc/omc3/pull/564.
- I've clarified / docstring some parts of the internal APIs. I've fixed a few type hints here and there and put some comments to stop `ty` from going crazy in places where it is wrong.
